### PR TITLE
Add maxUtterancesPerSecond switch to CLI run/test commands

### DIFF
--- a/packages/conversation-processor-cli/package-lock.json
+++ b/packages/conversation-processor-cli/package-lock.json
@@ -517,6 +517,11 @@
 				"p-limit": "^2.0.0"
 			}
 		},
+		"p-throttle": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/p-throttle/-/p-throttle-3.0.0.tgz",
+			"integrity": "sha512-+6Fy/Q1pSWETgbk6YKQxCAhZti74t84kESLL1QOTeGFCkMkjkA1QT4VBj8Bo5Lx4XpIG+bGQ5UhEAXVKbaF15w=="
+		},
 		"p-try": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",

--- a/packages/conversation-processor-cli/package.json
+++ b/packages/conversation-processor-cli/package.json
@@ -40,6 +40,7 @@
     "deep-diff": "^1.0.2",
     "inquirer": "^6.2.1",
     "moment": "^2.24.0",
+    "p-throttle": "^3.0.0",
     "yargs": "^12.0.5"
   },
   "devDependencies": {

--- a/packages/conversation-processor-cli/src/commands/repl.ts
+++ b/packages/conversation-processor-cli/src/commands/repl.ts
@@ -3,7 +3,7 @@
 import { IIntentResolver } from "conversation-processor";
 import * as inquirer from "inquirer";
 import * as util from "util";
-import { loadIntentResolverFromConfiguration } from "../conversation-processor-configuration";
+import { loadIntentResolverFromConfiguration } from "../intent-resolver-configuration";
 
 let intentResolver: IIntentResolver<any, any>|undefined;
 let currentConfigFile: string|undefined;

--- a/packages/conversation-processor-cli/src/index.ts
+++ b/packages/conversation-processor-cli/src/index.ts
@@ -5,7 +5,6 @@ import { startReplLoop } from "./commands/repl";
 import { executeRunCommand } from "./commands/run";
 import { executeTestCommand } from "./commands/test";
 
-
 // tslint:disable-next-line:no-unused-expression
 yargs
     .command(
@@ -19,7 +18,7 @@ yargs
                 })),
         (argv) => startReplLoop(argv.config as string))
     .command(
-        "run <config> <inputs> [output]",
+        "run <config> <inputs> [output] [--maxUtterancesPerSecond 5]",
         "Takes a set of inputs and runs all of them through a specified configuration. The output format for this command is the same as the input file format. This command can be used to generate input files for use with the test command as well.",
         (y) => (y.positional(
                     "config",
@@ -40,33 +39,48 @@ yargs
                         alias: "o",
                         describe: "A path to where an output file will be written for the run. If not supplied, output will be written to the console.",
                         type: "string",
-                    })),
-        (argv) => executeRunCommand(argv.config as string, argv.inputs as string, argv.output as string))
-        .command(
-            "test <config> <inputs> [output] [--diff=false]",
-            "Takes a set of inputs and runs all of them through a specified configuration. This command includes additional output details such as execution timings as well as recognition diffs when the --diff switch is specified.",
-            (y) => (y.positional(
-                        "config",
-                        {
-                            describe: "The conversation configuration file to use for the run.",
-                            type: "string",
-                        })
-                    .positional(
-                        "inputs",
-                        {
-                            alias: "i",
-                            describe: "A path to a JSON file containing the inputs for the run.",
-                            type: "string",
-                        })
-                    .positional(
-                        "output",
-                        {
-                            alias: "o",
-                            describe: "A path to where an output file will be written for the run. If not supplied, output will be written to the console.",
-                            type: "string",
-                        })
-                    .boolean("diff")
-                    .default("diff", false)),
-            (argv) => executeTestCommand(argv.config as string, argv.inputs as string, argv.output as string, argv.diff))
+                    }))
+                .option("maxUtterancesPerSecond", {
+                    alias: "mups",
+                    number: true,
+                    default: 5,
+                    description: "The maximum number of utterances to process per second.",
+                }),
+        (argv) => executeRunCommand(argv.config as string, argv.inputs as string, argv.output as string, { maxUtterancesPerSecond: argv.maxUtterancesPerSecond }))
+    .command(
+        "test <config> <inputs> [output] [--diff] [--maxUtterancesPersecond 5]",
+        "Takes a set of inputs and runs all of them through a specified configuration. This command includes additional output details such as execution timings as well as recognition diffs when the --diff switch is specified.",
+        (y) => (y.positional(
+                    "config",
+                    {
+                        describe: "The conversation configuration file to use for the run.",
+                        type: "string",
+                    })
+                .positional(
+                    "inputs",
+                    {
+                        alias: "i",
+                        describe: "A path to a JSON file containing the inputs for the run.",
+                        type: "string",
+                    })
+                .positional(
+                    "output",
+                    {
+                        alias: "o",
+                        describe: "A path to where an output file will be written for the run. If not supplied, output will be written to the console.",
+                        type: "string",
+                    })
+                .option("maxUtterancesPerSecond", {
+                    alias: "mups",
+                    number: true,
+                    default: 5,
+                    description: "The maximum number of utterances to process per second.",
+                })
+                .option("diff", {
+                    boolean: true,
+                    default: false,
+                    description: "Use this switch to enable diffing of expected results from the input file with actual results from the test run.",
+                })),
+        (argv) => executeTestCommand(argv.config as string, argv.inputs as string, argv.output as string, { outputDiff: argv.diff, maxUtterancesPerSecond: argv.maxUtterancesPerSecond }))
     .wrap(yargs.terminalWidth())
     .argv;

--- a/packages/conversation-processor-cli/src/intent-resolver-configuration.ts
+++ b/packages/conversation-processor-cli/src/intent-resolver-configuration.ts
@@ -6,8 +6,6 @@ export interface IntentResolverConfiguration {
     readonly enrichers: Array<IIntentEnricher<any, Entity, Entity>>;
 }
 
-// tslint:disable:no-console
-
 export async function loadIntentResolverFromConfiguration(configFile: string) {
     // Make sure to delete it from the require cache first in case it's already loaded
     const fullConfigFilePath = path.resolve(configFile);


### PR DESCRIPTION
Introduces a `--maxUtterancesPerSecond <number>` switch to the
`run` and `test` commands that will throttle the processing by the
specified amount.

Other refactorings included:
 * Some cleanup of the yargs configuration
 * Rename of `conversation-processor-configuration` to
`intent-resolver-configuration`