### PR TITLE
Update config loading to support resolver factory

### DIFF
--- a/packages/intentalyzer-cli/package-lock.json
+++ b/packages/intentalyzer-cli/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "intentalyzer-cli",
-	"version": "0.0.1",
+	"version": "0.0.2-alpha.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -167,11 +167,6 @@
 			"integrity": "sha512-y51XRWWg1GiW4+mV2zmFQUqJT3bX7nuUaXW4j8a2dFvT9ZlaNLjb7ZxcUSDyklt/UBWrW2+31x+hQpRzxaTFzw==",
 			"dev": true
 		},
-		"ansi-escapes": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
-			"integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw=="
-		},
 		"ansi-regex": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
@@ -199,24 +194,6 @@
 				"escape-string-regexp": "^1.0.5",
 				"supports-color": "^5.3.0"
 			}
-		},
-		"chardet": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
-		},
-		"cli-cursor": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-			"requires": {
-				"restore-cursor": "^2.0.0"
-			}
-		},
-		"cli-width": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
 		},
 		"code-point-at": {
 			"version": "1.1.0",
@@ -285,24 +262,6 @@
 				"strip-eof": "^1.0.0"
 			}
 		},
-		"external-editor": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
-			"integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
-			"requires": {
-				"chardet": "^0.7.0",
-				"iconv-lite": "^0.4.24",
-				"tmp": "^0.0.33"
-			}
-		},
-		"figures": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-			"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-			"requires": {
-				"escape-string-regexp": "^1.0.5"
-			}
-		},
 		"find-up": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
@@ -329,33 +288,10 @@
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
 			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 		},
-		"iconv-lite": {
-			"version": "0.4.24",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-			"requires": {
-				"safer-buffer": ">= 2.1.2 < 3"
-			}
-		},
-		"inquirer": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.1.tgz",
-			"integrity": "sha512-088kl3DRT2dLU5riVMKKr1DlImd6X7smDhpXUCkJDCKvTEJeRiXh0G132HG9u5a+6Ylw9plFRY7RuTnwohYSpg==",
-			"requires": {
-				"ansi-escapes": "^3.0.0",
-				"chalk": "^2.0.0",
-				"cli-cursor": "^2.1.0",
-				"cli-width": "^2.0.0",
-				"external-editor": "^3.0.0",
-				"figures": "^2.0.0",
-				"lodash": "^4.17.10",
-				"mute-stream": "0.0.7",
-				"run-async": "^2.2.0",
-				"rxjs": "^6.1.0",
-				"string-width": "^2.1.0",
-				"strip-ansi": "^5.0.0",
-				"through": "^2.3.6"
-			}
+		"intentalyzer": {
+			"version": "0.0.2-alpha.0",
+			"resolved": "https://registry.npmjs.org/intentalyzer/-/intentalyzer-0.0.2-alpha.0.tgz",
+			"integrity": "sha512-k9OXoC1s7Ts9ZyrbpDNJpqAfhpJRvBaMntP0iOA9hZS3yYiHrVHVhRSxMz19NOkIoAF7stMJszcteCSrlOQSbQ=="
 		},
 		"invert-kv": {
 			"version": "2.0.0",
@@ -366,11 +302,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
 			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-		},
-		"is-promise": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
 		},
 		"is-stream": {
 			"version": "1.1.0",
@@ -398,11 +329,6 @@
 				"p-locate": "^3.0.0",
 				"path-exists": "^3.0.0"
 			}
-		},
-		"lodash": {
-			"version": "4.17.11",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-			"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
 		},
 		"map-age-cleaner": {
 			"version": "0.1.3",
@@ -432,11 +358,6 @@
 			"resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
 			"integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
 		},
-		"mute-stream": {
-			"version": "0.0.7",
-			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
-		},
 		"nice-try": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -463,14 +384,6 @@
 				"wrappy": "1"
 			}
 		},
-		"onetime": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-			"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-			"requires": {
-				"mimic-fn": "^1.0.0"
-			}
-		},
 		"os-locale": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
@@ -480,11 +393,6 @@
 				"lcid": "^2.0.0",
 				"mem": "^4.0.0"
 			}
-		},
-		"os-tmpdir": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
 		},
 		"p-defer": {
 			"version": "1.0.0",
@@ -556,36 +464,6 @@
 			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
 			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
 		},
-		"restore-cursor": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-			"requires": {
-				"onetime": "^2.0.0",
-				"signal-exit": "^3.0.2"
-			}
-		},
-		"run-async": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
-			"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
-			"requires": {
-				"is-promise": "^2.1.0"
-			}
-		},
-		"rxjs": {
-			"version": "6.3.3",
-			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.3.tgz",
-			"integrity": "sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==",
-			"requires": {
-				"tslib": "^1.9.0"
-			}
-		},
-		"safer-buffer": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-		},
 		"semver": {
 			"version": "5.6.0",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
@@ -633,21 +511,6 @@
 				}
 			}
 		},
-		"strip-ansi": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
-			"integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
-			"requires": {
-				"ansi-regex": "^4.0.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
-					"integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w=="
-				}
-			}
-		},
 		"strip-eof": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
@@ -660,24 +523,6 @@
 			"requires": {
 				"has-flag": "^3.0.0"
 			}
-		},
-		"through": {
-			"version": "2.3.8",
-			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
-		},
-		"tmp": {
-			"version": "0.0.33",
-			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-			"requires": {
-				"os-tmpdir": "~1.0.2"
-			}
-		},
-		"tslib": {
-			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-			"integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
 		},
 		"which": {
 			"version": "1.3.1",

--- a/packages/intentalyzer-cli/package.json
+++ b/packages/intentalyzer-cli/package.json
@@ -11,7 +11,7 @@
     "lib": "dist"
   },
   "bin": {
-    "convp": "dist/index.js"
+    "intentalyzer": "dist/index.js"
   },
   "files": [
     "dist"

--- a/packages/intentalyzer-cli/src/index.ts
+++ b/packages/intentalyzer-cli/src/index.ts
@@ -5,6 +5,8 @@ import { startReplLoop } from "./commands/repl";
 import { executeRunCommand } from "./commands/run";
 import { executeTestCommand } from "./commands/test";
 
+export * from "./intent-resolver-configuration";
+
 // tslint:disable-next-line:no-unused-expression
 yargs
     .command(

--- a/packages/tokenflow-integration/package-lock.json
+++ b/packages/tokenflow-integration/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "intentalyzer-tokenflow-integration",
-	"version": "0.0.1",
+	"version": "0.0.2-alpha.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -147,6 +147,11 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
 			"integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
+		},
+		"intentalyzer": {
+			"version": "0.0.2-alpha.0",
+			"resolved": "https://registry.npmjs.org/intentalyzer/-/intentalyzer-0.0.2-alpha.0.tgz",
+			"integrity": "sha512-k9OXoC1s7Ts9ZyrbpDNJpqAfhpJRvBaMntP0iOA9hZS3yYiHrVHVhRSxMz19NOkIoAF7stMJszcteCSrlOQSbQ=="
 		},
 		"is-callable": {
 			"version": "1.1.4",


### PR DESCRIPTION
This changes the config file structure slightly to allow for specifying either the explictly pipeline configuration as previously supported _OR_ a factory method that produces an `IntentResolver<...>`.