### PR TITLE
Add new role property to LuisEntity and map it

### DIFF
--- a/packages/luis-integration/src/index.ts
+++ b/packages/luis-integration/src/index.ts
@@ -10,6 +10,7 @@ export interface LuisEntity extends BasicLuisEntity {
     readonly type: "luis";
     readonly score?: number;
     readonly resolution?: any;
+    readonly role?: string;
 }
 
 export interface LuisCompositeEntity extends BasicLuisEntity {
@@ -65,6 +66,7 @@ function mapEntity(luisEntity: LUISRuntimeModels.EntityModel): LuisEntity {
         },
         score: luisEntity.score,
         resolution: luisEntity.resolution ? (luisEntity as LUISRuntimeModels.EntityWithResolution).resolution : null,
+        role: luisEntity.role as string,
     };
 }
 


### PR DESCRIPTION

LUIS gained a new, optional `role` property on its entity class,
so need to model that in our abstraction and map through when present.