### PR TITLE
Make LuisCompositeEntity children LuisEntity only

### DIFF
--- a/packages/luis-integration/src/create-luis-intentrecognizer.ts
+++ b/packages/luis-integration/src/create-luis-intentrecognizer.ts
@@ -120,6 +120,6 @@ function mapCompositeEntity(name: string, rawLuisCompositeEntity: any, entityIns
         name,
         value: entityInstanceDetails.text,
         type: "luis.composite",
-        children: mapEntities(rawLuisCompositeEntity),
+        children: mapEntities(rawLuisCompositeEntity) as LuisEntity[],
     };
 }

--- a/packages/luis-integration/src/types.ts
+++ b/packages/luis-integration/src/types.ts
@@ -13,7 +13,7 @@ export interface LuisEntity extends LuisEntityBase {
 
 export interface LuisCompositeEntity extends LuisEntityBase {
     readonly type: "luis.composite";
-    readonly children: BasicLuisEntity[];
+    readonly children: LuisEntity[];
 }
 
 export type BasicLuisEntity = LuisEntity | LuisCompositeEntity;

--- a/packages/luis-integration/tsconfig.json
+++ b/packages/luis-integration/tsconfig.json
@@ -5,10 +5,7 @@
         "composite": true,
         "outDir": "lib",
         "declaration": true,
-        "declarationMap": true,
-        "lib": [
-            "esnext.array"
-        ]
+        "declarationMap": true
     },    
     "include": ["./src"],
     "references": [{ "path": "../intentalyzer" }]


### PR DESCRIPTION
Small refactoring to change the `LuisCompositeEntity::children`
property from `BasicLuisEntity` to only `LuisEntity` because a
composite cannot contain a composite today, so there's no
reason to force type checking on consumers of the library for
an impossible scenario.