### PR TITLE
Fix fuzzy text matcher not returning all matches

### DIFF
--- a/packages/tokenflow-integration/src/fuzzy-text-matcher.ts
+++ b/packages/tokenflow-integration/src/fuzzy-text-matcher.ts
@@ -33,17 +33,26 @@ export class FuzzyTextMatcher<TMatch> {
         const hashed = stemmed.map(this.lexicon.termModel.hashTerm);
 
         const graph = this.tokenizer.generateGraph(hashed, stemmed);
-        const path = graph.findPath([], 0);
 
-        const matches: Array<FuzzyMatchResult<TMatch>> = [];
-        for (const edge of path.values()) {
-            const token = this.tokenizer.tokenFromEdge(edge);
-            if (isFuzzyMatchToken<TMatch>(token)) {
-                matches.push({ match: token.match, score: edge.score });
+        let matches: Array<FuzzyMatchResult<TMatch>> = [];
+
+        for (const edges of graph.edgeLists) {
+            for (const edge of edges) {
+                const token = this.tokenizer.tokenFromEdge(edge);
+
+                if (isFuzzyMatchToken<TMatch>(token)) {
+                    matches.push({ match: token.match, score: edge.score });
+                }
             }
         }
 
-        return matches.sort((a, b) => b.score - a.score);
+        // Filter out duplicate matches with scores that below the threshold
+        matches = matches.filter((t) => t.score > 0);
+
+        // Sort the matches by score (highest to lowest)
+        matches = matches.sort( (a, b) => b.score - a.score);
+
+        return matches;
     }
 }
 

--- a/packages/tokenflow-integration/tests/fuzzy-text-matcher.test.ts
+++ b/packages/tokenflow-integration/tests/fuzzy-text-matcher.test.ts
@@ -77,30 +77,30 @@ describe("matches tests", () => {
 
     test("Match multiple patterns for same result", () => {
         const fuzzyTextMatcher = new FuzzyTextMatcher<TestItemDefinition>([
-            { pattern: "one", match: { id: 123, name: "One Two Three" }  },
-            { pattern: "one two", match: { id: 123, name: "One Two Three" }  },
-            { pattern: "one two three", match: { id: 123, name: "One Two Three" }  },
-            { pattern: "four five six", match: { id: 456, name: "Four Five Six" }  },
-            { pattern: "seven eight nine", match: { id: 789, name: "Seven Eight Nine" }  },
+            { pattern: "valueA", match: { id: 1, name: "A" }  },
+            { pattern: "valueA valueB", match: { id: 2, name: "A B" }  },
+            { pattern: "valueA valueB valueC", match: { id: 3, name: "A B C" }  },
+            { pattern: "valueD valueE valueF", match: { id: 4, name: "D E F" }  },
+            { pattern: "valueG valueH valueI", match: { id: 5, name: "G H I" }  },
         ].values());
 
-        let matches = fuzzyTextMatcher.matches("one");
+        let matches = fuzzyTextMatcher.matches("valueA");
+
+        expect(matches).not.toBeUndefined();
+        expect(matches.length).toBe(3);
+        expect(matches[0].match.id).toBe(1);
+
+        matches = fuzzyTextMatcher.matches("valueB");
+
+        expect(matches).not.toBeUndefined();
+        expect(matches.length).toBe(2);
+        expect(matches[0].match.id).toBe(2);
+
+        matches = fuzzyTextMatcher.matches("valueC");
 
         expect(matches).not.toBeUndefined();
         expect(matches.length).toBe(1);
-        expect(matches[0].match.id).toBe(123);
-
-        matches = fuzzyTextMatcher.matches("one two");
-
-        expect(matches).not.toBeUndefined();
-        expect(matches.length).toBe(1);
-        expect(matches[0].match.id).toBe(123);
-
-        matches = fuzzyTextMatcher.matches("one two three");
-
-        expect(matches).not.toBeUndefined();
-        expect(matches.length).toBe(1);
-        expect(matches[0].match.id).toBe(123);
+        expect(matches[0].match.id).toBe(3);
 
     });
 });


### PR DESCRIPTION

The matching algorithm was not considering all possible matches.
MikeH revised his sample and this is represents the port of that.