### PR TITLE
Add fuzzy matcher distinct check + thresh config

### DIFF
--- a/packages/tokenflow-integration/src/fuzzy-text-matcher.ts
+++ b/packages/tokenflow-integration/src/fuzzy-text-matcher.ts
@@ -38,13 +38,18 @@ export class FuzzyTextMatcher<TMatch> {
 
         for (const edges of graph.edgeLists) {
             for (const edge of edges) {
+                // If this edge is below the min-score threshold, just skip it
+                if (edge.score < this.minScoreThreshold) {
+                    continue;
+                }
+
                 const token = this.tokenizer.tokenFromEdge(edge);
 
                 if (isFuzzyMatchToken<TMatch>(token)) {
                     const match = token.match;
                     const existingMatch = distinctMatches.get(match);
 
-                    // If there isn't an existing match or this match is a higher score than the existing one, add it
+                    // If there isn't already an existing match or this match has a higher score than the existing one, add it
                     if (existingMatch === undefined
                             ||
                         edge.score > existingMatch.score) {
@@ -54,9 +59,8 @@ export class FuzzyTextMatcher<TMatch> {
             }
         }
 
-        // Filter matches with scores below the threshold and sort the matches by score (highest to lowest)
+        // Sort the matches by score (highest to lowest)
         const filteredAndSortedMatches = Array.from(distinctMatches.values())
-            .filter((e) => e.score >= this.minScoreThreshold)
             .sort((lhe, rhe) => rhe.score - lhe.score);
 
         return filteredAndSortedMatches;

--- a/packages/tokenflow-integration/src/individual-entity-transformer.ts
+++ b/packages/tokenflow-integration/src/individual-entity-transformer.ts
@@ -12,11 +12,12 @@ export type EntityWordSelector<TEntity extends Entity> = (entity: TEntity) => st
 
 export function createTokenFlowEntityTransform<TConversationContext, TEntity extends Entity, TFuzzyMatch>(
     entityWordSelector: EntityWordSelector<TEntity>,
-    fuzzyItemDefinitions: IterableIterator<FuzzyItemDefinition<TFuzzyMatch>>): IIntentTransform<TConversationContext, TEntity, TEntity|TEntity & TokenFlowMatchedEntity<TFuzzyMatch>> {
+    fuzzyItemDefinitions: IterableIterator<FuzzyItemDefinition<TFuzzyMatch>>,
+    minScoreThreshold: number = 0): IIntentTransform<TConversationContext, TEntity, TEntity|TEntity & TokenFlowMatchedEntity<TFuzzyMatch>> {
 
     debugLogger("Creating a new token-flow entity transform...");
 
-    const entityFuzzyTextMatcher = new FuzzyTextMatcher(fuzzyItemDefinitions, /* debugMode */ false);
+    const entityFuzzyTextMatcher = new FuzzyTextMatcher(fuzzyItemDefinitions, /* minScoreThreshold */ 0, /* debugMode */ false);
 
     function* processEntities(entities: TEntity[]): IterableIterator<TEntity | TEntity & TokenFlowMatchedEntity<TFuzzyMatch>> {
         for (const entity of entities) {

--- a/packages/tokenflow-integration/tests/fuzzy-text-matcher.test.ts
+++ b/packages/tokenflow-integration/tests/fuzzy-text-matcher.test.ts
@@ -103,4 +103,20 @@ describe("matches tests", () => {
         expect(matches[0].match.id).toBe(3);
 
     });
+
+    test("Filters results below the min threshold", () => {
+        const fuzzyTextMatcher = new FuzzyTextMatcher<TestItemDefinition>([
+            { pattern: "valueA", match: { id: 1, name: "A" }  },
+            { pattern: "valueA valueB", match: { id: 2, name: "A B" }  },
+            { pattern: "valueA valueB valueC", match: { id: 3, name: "A B C" }  },
+            { pattern: "valueD valueE valueF", match: { id: 4, name: "D E F" }  },
+            { pattern: "valueG valueH valueI", match: { id: 5, name: "G H I" }  },
+        ].values(),
+        .5);
+
+        const matches = fuzzyTextMatcher.matches("valueA");
+
+        expect(matches).not.toBeUndefined();
+        expect(matches.length).toBe(2);
+    });
 });


### PR DESCRIPTION
 * Adds distinct check for matches so that multiple edges don't
add the same logical match more than once (NOTE: highest score wins)
 * Added support for configuring a minimum score threshold and all
matches below that score will be discarded