### PR TITLE
LUIS prediction call context parameter support

### DIFF
--- a/packages/luis-integration/src/create-luis-intentrecognizer.ts
+++ b/packages/luis-integration/src/create-luis-intentrecognizer.ts
@@ -146,5 +146,9 @@ function mapCompositeEntity(name: string, rawLuisCompositeEntity: any, entityIns
         value: entityInstanceDetails.text,
         type: "luis.composite",
         children: mapEntities(rawLuisCompositeEntity) as LuisBasicEntity[],
+        utteranceOffsets: {
+            startIndex: entityInstanceDetails.startIndex,
+            endIndex: entityInstanceDetails.startIndex + entityInstanceDetails.length - 1,
+        },
     };
 }

--- a/packages/luis-integration/src/types.ts
+++ b/packages/luis-integration/src/types.ts
@@ -2,7 +2,7 @@ import { DynamicList, ExternalEntity } from "@azure/cognitiveservices-luis-runti
 import { CompositeEntity, Entity, isCompositeEntity } from "intentalyzer";
 
 export interface LuisEnrichedConversationContext {
-    readonly predictionCallContext?: LuisPredictionCallContext;
+    predictionCallContext?: LuisPredictionCallContext;
 }
 
 export function isLuisEnrichedConversationContext(conversationContext: any): conversationContext is LuisEnrichedConversationContext {

--- a/packages/luis-integration/src/types.ts
+++ b/packages/luis-integration/src/types.ts
@@ -1,4 +1,18 @@
+import { DynamicList, ExternalEntity } from "@azure/cognitiveservices-luis-runtime/esm/models";
 import { CompositeEntity, Entity, isCompositeEntity } from "intentalyzer";
+
+export interface LuisEnrichedConversationContext {
+    readonly predictionCallContext?: LuisPredictionCallContext;
+}
+
+export function isLuisEnrichedConversationContext(conversationContext: any): conversationContext is LuisEnrichedConversationContext {
+    return (conversationContext as LuisEnrichedConversationContext).predictionCallContext !== undefined;
+}
+
+export interface LuisPredictionCallContext {
+    readonly dynamicLists?: DynamicList[];
+    readonly externalEntities?: ExternalEntity[];
+}
 
 interface LuisEntityBase extends Entity {
     readonly $raw: any;


### PR DESCRIPTION
Introduces support for passing specific parameters into the LUIS prediction request. This enables passing both external entities and dynamic lists via the conversation context parameter by enriching it.