### PR TITLE
Support for generically composing intent resolvers

### DIFF
--- a/packages/intentalyzer/src/create-intent-resolver-transform.ts
+++ b/packages/intentalyzer/src/create-intent-resolver-transform.ts
@@ -1,9 +1,9 @@
 import { Entity, IIntentResolver, IIntentTransform } from ".";
 import { RecognizedIntent } from "./core-types";
 
-export type RecognizedIntentAggregator = <TEntity extends Entity, TTransformedEntity extends Entity>(originalRecognizedIntent: RecognizedIntent<TEntity>, newlyRecognizedIntent: RecognizedIntent<TTransformedEntity>) => RecognizedIntent<TTransformedEntity>;
+export type RecognizedIntentAggregator<TEntity extends Entity, TTransformedEntity extends Entity> = (originalRecognizedIntent: RecognizedIntent<TEntity>, newlyRecognizedIntent: RecognizedIntent<TTransformedEntity>) => RecognizedIntent<TTransformedEntity>;
 
-export function createIntentResolverTransform<TConversationContext, TEntity extends Entity, TTransformedEntity extends Entity>(intentResolver: IIntentResolver<TConversationContext, TTransformedEntity>, intentAggregator?: RecognizedIntentAggregator): IIntentTransform<TConversationContext, TEntity, TEntity | TTransformedEntity> {
+export function createIntentResolverTransform<TConversationContext, TEntity extends Entity, TTransformedEntity extends Entity>(intentResolver: IIntentResolver<TConversationContext, TTransformedEntity>, intentAggregator?: RecognizedIntentAggregator<TEntity, TTransformedEntity>): IIntentTransform<TConversationContext, TEntity,  TEntity | TTransformedEntity> {
     return {
         apply: async (c, ri) => {
             const newlyRecognizedIntent = await intentResolver.processUtterance(c, ri.utterance);

--- a/packages/intentalyzer/src/create-intent-resolver-transform.ts
+++ b/packages/intentalyzer/src/create-intent-resolver-transform.ts
@@ -1,0 +1,16 @@
+import { Entity, IIntentResolver, IIntentTransform } from ".";
+
+export function createIntentResolverTransform<TConversationContext, TEntity extends Entity, TTransformedEntity extends Entity>(intentResolver: IIntentResolver<TConversationContext, TTransformedEntity>): IIntentTransform<TConversationContext, TEntity, TEntity | TTransformedEntity> {
+    return {
+        apply: async (c, ri) => {
+            const newlyRecognizedIntent = await intentResolver.processUtterance(c, ri.utterance);
+
+            // If the resolver didn't produce a new recognized intent, just return the original
+            if (newlyRecognizedIntent === null) {
+                return ri;
+            }
+
+            return newlyRecognizedIntent;
+        },
+    };
+}

--- a/packages/intentalyzer/src/index.ts
+++ b/packages/intentalyzer/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./core-types";
 export * from "./create-intent-resolver";
+export * from "./create-intent-resolver-transform";
 export * from "./create-recognizer-chain";
 export * from "./create-transform-pipeline";
 export * from "./entities";


### PR DESCRIPTION
The primary work here is the introduction of a new transform that actually takes an intent resolver and applies it like a transform which can actually invoke an entirely separate intent resolver.