### PR TITLE
Make utteranceOffsets non-optional LuisBaseEntity

### DIFF
--- a/packages/luis-integration/src/create-luis-intentrecognizer.ts
+++ b/packages/luis-integration/src/create-luis-intentrecognizer.ts
@@ -132,6 +132,7 @@ function mapSingleEntityValue(name: string, value: any, entityInstanceDetails: a
         utteranceOffsets: {
             startIndex: entityInstanceDetails.startIndex,
             endIndex: entityInstanceDetails.startIndex + entityInstanceDetails.length - 1,
+            length: entityInstanceDetails.length,
         },
         // score: entityInstanceDetails.score,
     };
@@ -149,6 +150,7 @@ function mapCompositeEntity(name: string, rawLuisCompositeEntity: any, entityIns
         utteranceOffsets: {
             startIndex: entityInstanceDetails.startIndex,
             endIndex: entityInstanceDetails.startIndex + entityInstanceDetails.length - 1,
+            length: entityInstanceDetails.length,
         },
     };
 }

--- a/packages/luis-integration/src/types.ts
+++ b/packages/luis-integration/src/types.ts
@@ -17,6 +17,11 @@ export interface LuisPredictionCallContext {
 interface LuisEntityBase extends Entity {
     readonly $raw: any;
     readonly value: any;
+    readonly utteranceOffsets: {
+        startIndex: number;
+        endIndex: number;
+        length: number;
+    };
 }
 
 export interface LuisBasicEntity extends LuisEntityBase {


### PR DESCRIPTION
We will always have `utteranceOffsets` from LUIS, so explicitly update
`LuisBaseEntity` as non-optional _over_ the base most `Entity`
interface.

Also adds `length` property to the LuisBaseEntity `utteranceOffsets` type because LUIS always
gives that value for free any way. This will help downstream consumers as
they will now not have to each calculate the length from the indexes
themselves if they need it.