### PR TITLE
Pin @azure/ms-rest-js and @azure/cognitiveservices-luis-runtime packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3746,8 +3746,7 @@
                 "ansi-regex": {
                     "version": "2.1.1",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "aproba": {
                     "version": "1.2.0",
@@ -3768,14 +3767,12 @@
                 "balanced-match": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -3790,20 +3787,17 @@
                 "code-point-at": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
@@ -3920,8 +3914,7 @@
                 "inherits": {
                     "version": "2.0.3",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "ini": {
                     "version": "1.3.5",
@@ -3933,7 +3926,6 @@
                     "version": "1.0.0",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -3948,7 +3940,6 @@
                     "version": "3.0.4",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
@@ -3956,14 +3947,12 @@
                 "minimist": {
                     "version": "0.0.8",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "minipass": {
                     "version": "2.3.5",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.2",
                         "yallist": "^3.0.0"
@@ -3982,7 +3971,6 @@
                     "version": "0.5.1",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
@@ -4063,8 +4051,7 @@
                 "number-is-nan": {
                     "version": "1.0.1",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
@@ -4076,7 +4063,6 @@
                     "version": "1.4.0",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -4162,8 +4148,7 @@
                 "safe-buffer": {
                     "version": "5.1.2",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "safer-buffer": {
                     "version": "2.1.2",
@@ -4199,7 +4184,6 @@
                     "version": "1.0.2",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -4219,7 +4203,6 @@
                     "version": "3.0.1",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
                     }
@@ -4263,14 +4246,12 @@
                 "wrappy": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "yallist": {
                     "version": "3.0.3",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 }
             }
         },

--- a/packages/intentalyzer/src/entities.ts
+++ b/packages/intentalyzer/src/entities.ts
@@ -4,6 +4,7 @@ export interface Entity {
     readonly utteranceOffsets?: {
         startIndex: number;
         endIndex: number;
+        length?: number;
     };
 }
 

--- a/packages/luis-integration/package-lock.json
+++ b/packages/luis-integration/package-lock.json
@@ -1,25 +1,25 @@
 {
 	"name": "intentalyzer-luis-integration",
-	"version": "0.1.1-beta.0",
+	"version": "0.4.1-beta",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
 		"@azure/cognitiveservices-luis-runtime": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@azure/cognitiveservices-luis-runtime/-/cognitiveservices-luis-runtime-3.0.0.tgz",
-			"integrity": "sha512-cVsUoVs26ivOi3+SdZIt6+BBPCvEUaYUqYIN4b5jod2EAI/I1sNx703sPla9ka/yehWbtGISUDTxH6p+Eck+SQ==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@azure/cognitiveservices-luis-runtime/-/cognitiveservices-luis-runtime-3.0.1.tgz",
+			"integrity": "sha512-+c8viHdkVVN24eXmtxsyUzHfBEZwUNgIKBlUDefc2JxsVIhMRESRTtjr4ZuiYczywzWacIT8hPNuVopqp4JA9g==",
 			"requires": {
 				"@azure/ms-rest-js": "^1.8.1",
 				"tslib": "^1.9.3"
 			}
 		},
 		"@azure/ms-rest-js": {
-			"version": "1.8.7",
-			"resolved": "https://registry.npmjs.org/@azure/ms-rest-js/-/ms-rest-js-1.8.7.tgz",
-			"integrity": "sha512-JTVf4hu+/TnOQW1bprK+wxCBgJdZR6aC3oeAW35CfbxL4NVVgwEQ4+c1JOG8ph0WHGEL8bfyDF2vIjV/RuHkdg==",
+			"version": "1.8.13",
+			"resolved": "https://registry.npmjs.org/@azure/ms-rest-js/-/ms-rest-js-1.8.13.tgz",
+			"integrity": "sha512-jAa6Y2XrvwbEqkaEXDHK+ReNo0WnCPS+LgQ1dRAJUUNxK4CghF5u+SXsVtPENritilVE7FVteqsLOtlhTk+haA==",
 			"requires": {
 				"@types/tunnel": "0.0.0",
-				"axios": "^0.18.0",
+				"axios": "^0.19.0",
 				"form-data": "^2.3.2",
 				"tough-cookie": "^2.4.3",
 				"tslib": "^1.9.2",
@@ -63,12 +63,11 @@
 			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
 		},
 		"axios": {
-			"version": "0.18.0",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
-			"integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
+			"version": "0.19.2",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+			"integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
 			"requires": {
-				"follow-redirects": "^1.3.0",
-				"is-buffer": "^1.1.5"
+				"follow-redirects": "1.5.10"
 			}
 		},
 		"combined-stream": {
@@ -80,11 +79,11 @@
 			}
 		},
 		"debug": {
-			"version": "3.2.6",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-			"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+			"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
 			"requires": {
-				"ms": "^2.1.1"
+				"ms": "2.0.0"
 			}
 		},
 		"define-properties": {
@@ -124,17 +123,17 @@
 			}
 		},
 		"follow-redirects": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.7.0.tgz",
-			"integrity": "sha512-m/pZQy4Gj287eNy94nivy5wchN3Kp+Q5WgUPNy5lJSZ3sgkVKSYV/ZChMAQVIgx1SqfZ2zBZtPA2YlXIWxxJOQ==",
+			"version": "1.5.10",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+			"integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
 			"requires": {
-				"debug": "^3.2.6"
+				"debug": "=3.1.0"
 			}
 		},
 		"form-data": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-			"integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+			"integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
 			"requires": {
 				"asynckit": "^0.4.0",
 				"combined-stream": "^1.0.6",
@@ -160,14 +159,9 @@
 			"integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
 		},
 		"intentalyzer": {
-			"version": "0.1.1-beta.0",
-			"resolved": "https://registry.npmjs.org/intentalyzer/-/intentalyzer-0.1.1-beta.0.tgz",
-			"integrity": "sha512-cNojRwPUU9TOKQe6ZVyBVNPcOYSvmCuLTmhVOMo7EJeWeRWzxTcwAKrhV7LfquoH1f6LLbuXh3AHbJEAjLWqPQ=="
-		},
-		"is-buffer": {
-			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+			"version": "0.3.0-beta",
+			"resolved": "https://registry.npmjs.org/intentalyzer/-/intentalyzer-0.3.0-beta.tgz",
+			"integrity": "sha512-Ru8a1mDPpqFbhxrkxCgA6QnAKMAb66bwoXm3i0Z3ctYMRecr/i/zgE/VQ22AtOFSs2H5QV39T5cf0LyVu03U1Q=="
 		},
 		"is-callable": {
 			"version": "1.1.4",
@@ -196,22 +190,22 @@
 			}
 		},
 		"mime-db": {
-			"version": "1.40.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
-			"integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
+			"version": "1.43.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
+			"integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
 		},
 		"mime-types": {
-			"version": "2.1.24",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
-			"integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
+			"version": "2.1.26",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
+			"integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
 			"requires": {
-				"mime-db": "1.40.0"
+				"mime-db": "1.43.0"
 			}
 		},
 		"ms": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-			"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 		},
 		"object-keys": {
 			"version": "1.1.1",
@@ -219,9 +213,9 @@
 			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
 		},
 		"psl": {
-			"version": "1.1.31",
-			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
-			"integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw=="
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.7.0.tgz",
+			"integrity": "sha512-5NsSEDv8zY70ScRnOTn7bK7eanl2MvFrOrS/R6x+dBt5g1ghnj9Zv90kO8GwT8gxcu2ANyFprnFYB85IogIJOQ=="
 		},
 		"punycode": {
 			"version": "2.1.1",
@@ -243,9 +237,9 @@
 			}
 		},
 		"tslib": {
-			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-			"integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+			"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
 		},
 		"tunnel": {
 			"version": "0.0.6",
@@ -253,23 +247,23 @@
 			"integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
 		},
 		"uuid": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
 		},
 		"xml2js": {
-			"version": "0.4.19",
-			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-			"integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+			"version": "0.4.23",
+			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+			"integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
 			"requires": {
 				"sax": ">=0.6.0",
-				"xmlbuilder": "~9.0.1"
+				"xmlbuilder": "~11.0.0"
 			}
 		},
 		"xmlbuilder": {
-			"version": "9.0.7",
-			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-			"integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+			"version": "11.0.1",
+			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+			"integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
 		}
 	}
 }

--- a/packages/luis-integration/package.json
+++ b/packages/luis-integration/package.json
@@ -33,7 +33,8 @@
     "url": "https://github.com/cmayomsft/domain-specific-entities-node/issues"
   },
   "dependencies": {
-    "@azure/cognitiveservices-luis-runtime": "^3.0.0",
+    "@azure/cognitiveservices-luis-runtime": "3.0.1",
+    "@azure/ms-rest-js": "1.8.13",
     "array.prototype.flatmap": "^1.2.1",
     "intentalyzer": "^0.3.0-beta"
   },

--- a/packages/luis-integration/src/types.ts
+++ b/packages/luis-integration/src/types.ts
@@ -17,10 +17,10 @@ export interface LuisPredictionCallContext {
 interface LuisEntityBase extends Entity {
     readonly $raw: any;
     readonly value: any;
-    readonly utteranceOffsets: {
+    readonly utteranceOffsets?: {
         startIndex: number;
         endIndex: number;
-        length: number;
+        length?: number;
     };
 }
 


### PR DESCRIPTION
Fixes #48 , see the issue for a detailed description of bug. 

tldr; `@azure/ms-rest-js` was causing issues because of differing versions between package dependencies.

Also fixes some type discrepancies, i.e. the following error...
```ts
$ npm run build

> intentalyzer-luis-integration@0.4.1-beta build /Users/tkerchev/spacekatt_projects/domain-specific-entities-node/packages/luis-integration
> tsc --build .

src/types.ts:48:18 - error TS2320: Interface 'LuisCompositeEntity' cannot simultaneously extend types 'LuisEntityBase' and 'CompositeEntity<LuisBasicEntity>'.
  Named property 'utteranceOffsets' of types 'LuisEntityBase' and 'CompositeEntity<LuisBasicEntity>' are not identical.

48 export interface LuisCompositeEntity extends LuisEntityBase, CompositeEntity<LuisBasicEntity> {
                    ~~~~~~~~~~~~~~~~~~~


Found 1 error.

npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! intentalyzer-luis-integration@0.4.1-beta build: `tsc --build .`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the intentalyzer-luis-integration@0.4.1-beta build script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/tkerchev/.npm/_logs/2020-02-03T18_49_51_075Z-debug.log
```